### PR TITLE
Fix build with Go v1.22.1, liboqs v0.10.0

### DIFF
--- a/examples/client_server_kem/client/client_kem.go
+++ b/examples/client_server_kem/client/client_kem.go
@@ -64,8 +64,8 @@ func main() {
 		log.Fatal(err)
 	} else if n != client.Details().LengthCiphertext {
 		log.Fatal(errors.New("client expected to read " +
-			string(client.Details().LengthCiphertext) + " bytes, but instead " +
-			"read " + string(n)))
+			fmt.Sprintf("%v", client.Details().LengthCiphertext) + " bytes, but instead " +
+			"read " + fmt.Sprintf("%v", n)))
 	}
 
 	// decapsulate the secret and extract the shared secret

--- a/examples/client_server_kem/server/server_kem.go
+++ b/examples/client_server_kem/server/server_kem.go
@@ -97,8 +97,8 @@ func handleConnection(conn net.Conn, kemName string) {
 		log.Fatal(err)
 	} else if n != server.Details().LengthPublicKey {
 		log.Fatal(errors.New("server expected to read " +
-			string(server.Details().LengthPublicKey) + " bytes, but instead " +
-			"read " + string(n)))
+			fmt.Sprintf("%v", server.Details().LengthPublicKey) + " bytes, but instead " +
+			"read " + fmt.Sprintf("%v", n)))
 	}
 
 	// encapsulate the secret
@@ -112,8 +112,8 @@ func handleConnection(conn net.Conn, kemName string) {
 	if err != nil {
 		log.Fatal(err)
 	} else if n != server.Details().LengthCiphertext {
-		log.Fatal(errors.New("server expected to write " + string(server.
-			Details().LengthCiphertext) + " bytes, but instead wrote " + string(n)))
+		log.Fatal(errors.New("server expected to write " + fmt.Sprintf("%v", server.
+			Details().LengthCiphertext) + " bytes, but instead wrote " + fmt.Sprintf("%v", n)))
 	}
 
 	log.Printf("\nConnection #%d - server shared secret:\n% X ... % X\n\n",

--- a/examples/rand/rand.go
+++ b/examples/rand/rand.go
@@ -3,9 +3,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/open-quantum-safe/liboqs-go/oqs"
 	"log"
 	"runtime"
+
+	"github.com/open-quantum-safe/liboqs-go/oqs"
 
 	oqsrand "github.com/open-quantum-safe/liboqs-go/oqs/rand" // RNG support
 )
@@ -21,19 +22,6 @@ func CustomRNG(randomArray []byte, bytesToRead int) {
 
 func main() {
 	fmt.Println("liboqs version: " + oqs.LiboqsVersion())
-
-	if err := oqsrand.RandomBytesSwitchAlgorithm("NIST-KAT"); err != nil {
-		log.Fatal(err)
-	}
-	// set the entropy seed to some values
-	var entropySeed [48]byte
-	for i := 0; i < 48; i++ {
-		entropySeed[i] = byte(i)
-	}
-	if err := oqsrand.RandomBytesNistKatInit256bit(entropySeed, nil); err != nil {
-		log.Fatal(err)
-	}
-	fmt.Printf("%-18s% X\n", "NIST-KAT: ", oqsrand.RandomBytes(32))
 
 	if err := oqsrand.RandomBytesCustomAlgorithm(CustomRNG); err != nil {
 		log.Fatal(err)

--- a/oqs/rand/rand.go
+++ b/oqs/rand/rand.go
@@ -72,30 +72,6 @@ func RandomBytesSwitchAlgorithm(algName string) error {
 	return nil
 }
 
-// RandomBytesNistKatInit256bit initializes the NIST DRBG with the entropyInput
-// seed, which must be 48 exactly bytes long. The personalizationString is an
-// optional personalization string, which, if non-empty, must be at least 48
-// bytes long. The security parameter is 256 bits.
-func RandomBytesNistKatInit256bit(entropyInput [48]byte,
-	personalizationString []byte) error {
-	lenStr := len(personalizationString)
-	if lenStr > 0 {
-		if lenStr < 48 {
-			return errors.New("the personalization string must be either " +
-				"empty or at least 48 bytes long")
-		}
-
-		C.OQS_randombytes_nist_kat_init_256bit(
-			(*C.uint8_t)(unsafe.Pointer(&entropyInput[0])),
-			(*C.uint8_t)(unsafe.Pointer(&personalizationString[0])))
-		return nil
-	}
-	C.OQS_randombytes_nist_kat_init_256bit(
-		(*C.uint8_t)(unsafe.Pointer(&entropyInput[0])),
-		(*C.uint8_t)(unsafe.Pointer(nil)))
-	return nil
-}
-
 // RandomBytesCustomAlgorithm switches RandomBytes to use the given function.
 // This allows additional custom RNGs besides the provided ones. The provided
 // RNG function must have the same signature as RandomBytesInPlace,


### PR DESCRIPTION
This fixes the build with newer toolchain, liboqs versions:

 - liboqs v0.10.0 drops support for the NIST KAT Random source in https://github.com/open-quantum-safe/liboqs/commit/cc453db4a6e02d97bf5fc974840ace881ffa6da1 from the public API.
 - This also fixes some places in the test suite where `go test ./...` fails due to calling `string(...)` on Go 1.22.1:

        > conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
