### PR TITLE
Fix for #49 and verification against liboqs 0.15.0

### DIFF
--- a/.config/liboqs-go.pc
+++ b/.config/liboqs-go.pc
@@ -3,7 +3,7 @@ LIBOQS_LIB_DIR=/usr/local/lib
 
 Name: liboqs-go
 Description: Go bindings for liboqs, a C library for quantum resistant cryptography
-Version: 0.10.0
+Version: 0.15.0
 Cflags: -I${LIBOQS_INCLUDE_DIR}
 Ldflags: '-extldflags "-Wl,-stack_size -Wl,0x1000000"'
 Libs: -L${LIBOQS_LIB_DIR} -loqs

--- a/.config/liboqs-go.pc.linux
+++ b/.config/liboqs-go.pc.linux
@@ -3,7 +3,7 @@ LIBOQS_LIB_DIR=/usr/local/lib
 
 Name: liboqs-go
 Description: Go bindings for liboqs, a C library for quantum resistant cryptography
-Version: 0.10.0
+Version: 0.15.0
 Cflags: -I${LIBOQS_INCLUDE_DIR}
 Ldflags: '-extldflags "-Wl,-stack_size -Wl,0x1000000"'
 Libs: -L${LIBOQS_LIB_DIR} -loqs

--- a/.config/liboqs-go.pc.win64
+++ b/.config/liboqs-go.pc.win64
@@ -3,7 +3,7 @@ LIBOQS_LIB_DIR=C:/liboqs/lib
 
 Name: liboqs-go
 Description: Go bindings for liboqs, a C library for quantum resistant cryptography
-Version: 0.10.0
+Version: 0.15.0
 Cflags: -I${LIBOQS_INCLUDE_DIR}
-Ldflags: '-extldflags "-Wl,-stack_size -Wl,0x1000000"'
+Ldflags: '-extldflags "-Wl,--stack,16777216"'
 Libs: -L${LIBOQS_LIB_DIR} -loqs

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           export PKG_CONFIG_PATH=${{env.POSIX_PKG_CONFIG_PATH}}
-          go test -v ./oqstests
+          go test -v -timeout 30m ./oqstests
 
       - name: Install liboqs Windows
         if: matrix.os == 'windows-latest'
@@ -86,4 +86,4 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           set PATH=%PATH%;${{env.WIN_LIBOQS_INSTALL_PATH}}\bin
-          go test -v .\oqstests
+          go test -v -timeout 30m .\oqstests

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,14 +13,13 @@ env:
   LD_LIBRARY_PATH: /usr/local/lib
   DYLD_LIBRARY_PATH: /usr/local/lib
   POSIX_PKG_CONFIG_PATH: ${{github.workspace}}/.config
-  WIN_LIBOQS_INSTALL_PATH: C:\liboqs
-  WIN_PKG_CONFIG_PATH: C:\Strawberry\c\lib\pkgconfig
 
 jobs:
-  build:
+  # POSIX builds (Linux, macOS)
+  build-posix:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -31,16 +30,14 @@ jobs:
         with:
           go-version: 1.21
 
-      - name: Install liboqs POSIX
-        if: matrix.os != 'windows-latest'
+      - name: Install liboqs
         run: |
           git clone --branch main --single-branch --depth 1 https://github.com/open-quantum-safe/liboqs
           cmake -S liboqs -B liboqs/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON -DOQS_BUILD_ONLY_LIB=ON
           cmake --build liboqs/build --parallel 4
           sudo cmake --build liboqs/build --target install
 
-      - name: Run examples POSIX
-        if: matrix.os != 'windows-latest'
+      - name: Run examples
         run: |
           export PKG_CONFIG_PATH=${{env.POSIX_PKG_CONFIG_PATH}}
           go run ./examples/kem/kem.go
@@ -49,41 +46,72 @@ jobs:
           echo
           go run ./examples/rand/rand.go
 
-      - name: Run unit tests POSIX
-        if: matrix.os != 'windows-latest'
+      - name: Run unit tests
         run: |
           export PKG_CONFIG_PATH=${{env.POSIX_PKG_CONFIG_PATH}}
           go test -v -timeout 30m ./oqstests
 
-      - name: Install liboqs Windows
-        if: matrix.os == 'windows-latest'
-        shell: cmd
+  # Windows build using MSYS2/MinGW
+  build-windows:
+    runs-on: windows-latest
+    env:
+      LIBOQS_INSTALL_PATH: C:/liboqs
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
+
+      - name: Set up MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          path-type: inherit
+          update: true
+          install: git mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-pkg-config
+
+      - name: Install liboqs
+        shell: msys2 {0}
         run: |
           git clone --branch main --single-branch --depth 1 https://github.com/open-quantum-safe/liboqs
-          cmake -S liboqs -B liboqs\build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.WIN_LIBOQS_INSTALL_PATH}} -DBUILD_SHARED_LIBS=ON -DOQS_BUILD_ONLY_LIB=ON
-          cmake --build liboqs\build --parallel 4
-          cmake --build liboqs\build --target install
+          cmake -S liboqs -B liboqs/build -G Ninja \
+            -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=$LIBOQS_INSTALL_PATH \
+            -DBUILD_SHARED_LIBS=ON \
+            -DOQS_BUILD_ONLY_LIB=ON \
+            -DCMAKE_C_FLAGS="-D__ORDER_LITTLE_ENDIAN__=1234 -D__ORDER_BIG_ENDIAN__=4321 -D__BYTE_ORDER__=1234"
+          cmake --build liboqs/build --parallel 4
+          cmake --build liboqs/build --target install
 
-      - name: Configure pkgconfig Windows
-        if: matrix.os == 'windows-latest'
-        shell: cmd
+      - name: Configure pkgconfig
+        shell: msys2 {0}
         run: |
-          copy .\.config\liboqs-go.pc.win64 ${{env.WIN_PKG_CONFIG_PATH}}\liboqs-go.pc
+          mkdir -p /mingw64/lib/pkgconfig
+          cp .config/liboqs-go.pc.win64 /mingw64/lib/pkgconfig/liboqs-go.pc
 
-      - name: Run examples Windows
-        if: matrix.os == 'windows-latest'
-        shell: cmd
+      - name: Run examples
+        shell: msys2 {0}
+        env:
+          CGO_ENABLED: 1
+          CC: gcc
+          PKG_CONFIG_PATH: /mingw64/lib/pkgconfig
         run: |
-          set PATH=%PATH%;${{env.WIN_LIBOQS_INSTALL_PATH}}\bin
-          go run .\examples\kem\kem.go
-          echo.
-          go run .\examples\sig\sig.go
-          echo.
-          go run .\examples\rand\rand.go
+          export PATH="/c/liboqs/bin:$PATH"
+          go run ./examples/kem/kem.go
+          echo
+          go run ./examples/sig/sig.go
+          echo
+          go run ./examples/rand/rand.go
 
-      - name: Run unit tests Windows
-        shell: cmd
-        if: matrix.os == 'windows-latest'
+      - name: Run unit tests
+        shell: msys2 {0}
+        env:
+          CGO_ENABLED: 1
+          CC: gcc
+          PKG_CONFIG_PATH: /mingw64/lib/pkgconfig
         run: |
-          set PATH=%PATH%;${{env.WIN_LIBOQS_INSTALL_PATH}}\bin
-          go test -v -timeout 30m .\oqstests
+          export PATH="/c/liboqs/bin:$PATH"
+          go test -v -timeout 30m ./oqstests

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,86 +1,82 @@
-# Version 0.12.0 - January 15, 2025
+# Changelog for liboqs-go
 
-- Fixes https://github.com/open-quantum-safe/liboqs-go/issues/44. The API that
-  NIST has introduced in [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final)
-  for ML-DSA includes a context string of length >= 0. Added new API for
-  signing with a context string
-  - `func (sig *Signature)
-SignWithCtxStr(message []byte, context []byte) ([]byte, error)`
-  - `func (sig *Signature)
-VerifyWithCtxStr(message []byte, signature []byte, context []byte,
-publicKey []byte) (bool, error)`
+## Version 0.15.0 - January 20, 2026
+
+- Updated compatibility for liboqs 0.15.0
+- **Breaking change:** Dilithium has been removed from liboqs 0.15.0.  Users must migrate to ML-DSA (FIPS 204)
+- SPHINCS+ is still supported in liboqs 0.15.0 but will be removed in liboqs 0.16.0 and replaced by SLH-DSA
+- liboqs 0.15.0 adds support for NTRU (re-added), updated CROSS to version 2.2, and includes SLH-DSA implementation
+- Updated GitHub Actions workflow to increase the test timeout from the default 10 minutes to 30 minutes.
+
+## Version 0.12.0 - January 15, 2025
+
+- Fixes [Issue #44](https://github.com/open-quantum-safe/liboqs-go/issues/44). The API that NIST has introduced in [FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) for ML-DSA includes a context string of length >= 0. Added new API for signing with a context string:
+
+> `func (sig *Signature) SignWithCtxStr(message []byte, context []byte) ([]byte, error)`
+
+> `func (sig *Signature) VerifyWithCtxStr(message []byte, signature []byte, context []byte, publicKey []byte) (bool, error)`
+
 - Updated examples to use `ML-KEM` and `ML-DSA` as the defaults
-- Removed the `oqs.rand` package and moved the `RandomBytes` family of 
-functions from `oqs.rand` to the main `oqs` package to avoid warnings about 
-linking liboqs twice
+- Removed the `oqs.rand` package and moved the `RandomBytes` family of functions from `oqs.rand` to the main `oqs` package to avoid warnings about linking liboqs twice
 
-# Version 0.10.0 - March 27, 2024
+## Version 0.10.0 - March 27, 2024
 
 - Bumped Go version to 1.21
-- Replaced CHANGES by
-  [CHANGES.md](https://github.com/open-quantum-safe/liboqs-go/blob/main/CHANGES.md),
-  as we now use Markdown format to keep track of changes in new releases
-- Removed the NIST PRNG as the latter is no longer exposed by liboqs' public
-  API
-- Added the
-  [.config-static](https://github.com/open-quantum-safe/liboqs-go/tree/main/.config-static)
-  pkg-config configuration directory for linking statically against liboqs, see
-  [README.md](https://github.com/open-quantum-safe/liboqs-go/blob/main/README.md)
-  for more details
+- Replaced CHANGES by [CHANGES.md](https://github.com/open-quantum-safe/liboqs-go/blob/main/CHANGES.md), as we now use Markdown format to keep track of changes in new releases
+- Removed the NIST PRNG as the latter is no longer exposed by liboqs' public API
+- Added the [.config-static](https://github.com/open-quantum-safe/liboqs-go/tree/main/.config-static) pkg-config configuration directory for linking statically against liboqs, see [README.md](https://github.com/open-quantum-safe/liboqs-go/blob/main/README.md) for more details
 
-# Version 0.9.0 - October 30, 2023
+## Version 0.9.0 - October 30, 2023
 
 - No modifications, release bumped to match the latest release of liboqs
 
-# Version 0.8.0 - July 5, 2023
+## Version 0.8.0 - July 5, 2023
 
 - This is a maintenance release, minor fixes
 - Minimalistic Docker support
 - Go minimum required version bumped to 1.15
-- Removed AppVeyor and CircleCI, all continuous integration is now done via
-  GitHub actions
+- Removed AppVeyor and CircleCI, all continuous integration is now done via GitHub actions
 
-# Version 0.7.2 - August 26, 2022
+## Version 0.7.2 - August 26, 2022
 
 - Added liboqs library version retrieval function `LiboqsVersion() string`
 
-# Version 0.7.1 - January 5, 2022
+## Version 0.7.1 - January 5, 2022
 
 - Release numbering updated to match liboqs
-- Switched continuous integration from Travis CI to CircleCI, we now support
-  macOS & Linux (CircleCI) and Windows (AppVeyor)
+- Switched continuous integration from Travis CI to CircleCI, we now support macOS & Linux (CircleCI) and Windows (AppVeyor)
 
-# Version 0.4.0 - November 28, 2020
+## Version 0.4.0 - November 28, 2020
 
 - Bugfixes
 - Renamed 'master' branch to 'main'
 
-# Version 0.3.0 - June 10, 2020
+## Version 0.3.0 - June 10, 2020
 
 - Full Windows support and AppVeyor continuous integration
 - Minor fixes
 
-# Version 0.2.2 - December 10, 2019
+## Version 0.2.2 - December 10, 2019
 
 - Changed panics to errors in the API
 
-# Version 0.2.1 - November 7, 2019
+## Version 0.2.1 - November 7, 2019
 
 - Added a client/server KEM over TCP/IP example
 
-# Version 0.2.0 - November 2, 2019
+## Version 0.2.0 - November 2, 2019
 
 - Minor API change to account for Go naming conventions
 - Concurrent unit testing
 
-# Version 0.1.2 - October 31, 2019
+## Version 0.1.2 - October 31, 2019
 
 - Added support for RNGs from `<oqs/rand.h>`
 
-# Version 0.1.1 - October 24, 2019
+## Version 0.1.1 - October 24, 2019
 
 - Added support for Go modules
 
-# Version 0.1.0 - October 22, 2019
+## Version 0.1.0 - October 22, 2019
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The project contains the following files and directories:
 
 ## Functional restrictions
 
-No known issues as of liboqs-0.12.0
+No known issues as of liboqs-0.15.0
+
+**Important:** As of liboqs 0.15.0, Dilithium has been removed. Users should migrate to ML-DSA (FIPS 204) instead. SPHINCS+ is still supported in liboqs 0.15.0 but will be removed in 0.16.0 and replaced by SLH-DSA.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ See in particular limitations on intended use.
 
 ## Release notes
 
-This release of liboqs-go was released on January 20, 2026. Its release page on
+This release of liboqs-go was released on January 26, 2026. Its release page on
 GitHub is https://github.com/open-quantum-safe/liboqs-go/releases/tag/0.15.0.
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# liboqs-go version 0.12.0
+# liboqs-go version 0.15.0
 
 ---
 
@@ -24,12 +24,12 @@ See in particular limitations on intended use.
 
 ## Release notes
 
-This release of liboqs-go was released on January 15, 2025. Its release page on
-GitHub is https://github.com/open-quantum-safe/liboqs-go/releases/tag/0.12.0.
+This release of liboqs-go was released on January 20, 2026. Its release page on
+GitHub is https://github.com/open-quantum-safe/liboqs-go/releases/tag/0.15.0.
 
 ---
 
 ## What's New
 
-This is the 14th release of liboqs-go. For a list of changes see
+This is the 15th release of liboqs-go. For a list of changes see
 [CHANGES.md](https://github.com/open-quantum-safe/liboqs-go/blob/main/CHANGES.md).


### PR DESCRIPTION
**Rationale**

The `liboqs-upstream-trigger` job has been failing for many months.  This PR verifies liboqs-go with the latest liboqs release and fixes #49 

**Notes for Reviewers**

This pull request updates the project to support liboqs version 0.15.0 and makes several important changes to documentation and build workflows. The most significant changes include updating version numbers, reflecting upstream cryptographic algorithm removals and additions, and improving the GitHub Actions workflow for both POSIX and Windows environments.

**Version and Compatibility Updates:**

* Updated all relevant version numbers and documentation to reference liboqs 0.15.0, including `.config/liboqs-go.pc`, `.config/liboqs-go.pc.linux`, `.config/liboqs-go.pc.win64`, `RELEASE.md`, and `CHANGES.md`. 

**Build and Continuous Integration Improvements:**

* Refactored the GitHub Actions workflow to separate POSIX and Windows builds, improving clarity and maintainability. The Windows build now uses MSYS2/MinGW for better compatibility (as per the README, as liboqs was defaulting to building with MSVC), and the test timeout has been increased to 30 minutes (required for SLH-DSA tests).
* Updated linker flags for Windows in `.config/liboqs-go.pc.win64` to use the correct stack size syntax for the platform.

**Documentation Enhancements:**

* Expanded and clarified the changelog in `CHANGES.md`, including details about cryptographic algorithm support and migration notes for users.
* Updated the functional restrictions section in `README.md` to match the new liboqs version and algorithm support status.