### PR TITLE
fix stack size on windows for heavy sigs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -98,6 +98,9 @@ jobs:
           CGO_ENABLED: 1
           CC: gcc
           PKG_CONFIG_PATH: /mingw64/lib/pkgconfig
+          # Larger stack reserve for stack-heavy sig schemes (e.g. MQOM2).
+          CGO_LDFLAGS: "-Wl,--stack,0x4000000"
+          CGO_LDFLAGS_ALLOW: "-Wl,--stack,.*"
         run: |
           export PATH="/c/liboqs/bin:$PATH"
           go run ./examples/kem/kem.go
@@ -112,6 +115,8 @@ jobs:
           CGO_ENABLED: 1
           CC: gcc
           PKG_CONFIG_PATH: /mingw64/lib/pkgconfig
+          CGO_LDFLAGS: "-Wl,--stack,0x4000000"
+          CGO_LDFLAGS_ALLOW: "-Wl,--stack,.*"
         run: |
           export PATH="/c/liboqs/bin:$PATH"
           go test -v -timeout 30m ./oqstests


### PR DESCRIPTION
fix for #51 

Copilot summary:

This pull request updates the GitHub Actions workflow for Go to address stack size requirements when building with CGO, specifically for stack-heavy signature schemes. The changes add linker flags to increase the stack reserve size in relevant workflow steps.

**Workflow configuration updates:**

* Increased stack reserve size by setting `CGO_LDFLAGS` to `-Wl,--stack,0x4000000` and allowing this flag with `CGO_LDFLAGS_ALLOW`, ensuring compatibility with stack-heavy signature schemes such as MQOM2 in both the example and test steps of `.github/workflows/go.yml`. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR101-R103) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fR118-R119)